### PR TITLE
Bug 915045 - [marionetee-js-client] Add getWindowType function in Client module.

### DIFF
--- a/lib/marionette/client.js
+++ b/lib/marionette/client.js
@@ -740,6 +740,18 @@
     },
 
     /**
+     * Returns the type of current window.
+     *
+     * @method getWindowType
+     * @param {Function} [callback] executes with window type.
+     * @return {Object} self.
+     */
+     getWindowType: function getWindowType(callback) {
+       var cmd = { type: 'getWindowType' };
+       return this._sendCommand(cmd, 'value', callback);
+     },
+
+    /**
      * Imports a script into the marionette
      * context for the duration of the session.
      *

--- a/test/marionette/client-test.js
+++ b/test/marionette/client-test.js
@@ -576,6 +576,16 @@ suite('marionette/client', function() {
       callbackReceives('ok');
   });
 
+  suite('.getWindowType', function() {
+    device.
+      issues('getWindowType').
+      shouldSend({
+        type: 'getWindowType'
+      }).
+      serverResponds('value').
+      callbackReceives('value');
+  });
+
   suite('.switchToFrame', function() {
     suite('when given nothing', function() {
       device.


### PR DESCRIPTION
Get current window type.
http://bugzil.la/915045
