### PR TITLE
Bug 979663 - [marionette-js-client] The documentation for the getAttribu...

### DIFF
--- a/lib/marionette/element.js
+++ b/lib/marionette/element.js
@@ -123,7 +123,7 @@
      * @method getAttribute
      * @param {String} attr attribtue name.
      * @param {Function} callback gets called with attribute's value.
-     * @return {Object} self.
+     * @return {String} the value of the Attribute.
      */
     getAttribute: function getAttribute(attr, callback) {
       var cmd = {


### PR DESCRIPTION
Replace the comment from "{Object} self." to "@return {String} the value of the Attribute.".
This function has been written by "return this._sendCommand(cmd, 'value', callback);"
Not "return this;", It seen as a function pointer when "@return {Object} self" ?
