### PR TITLE
Bug 979667 - Update the documentation for tagName method.

### DIFF
--- a/lib/marionette/element.js
+++ b/lib/marionette/element.js
@@ -189,6 +189,7 @@
     /**
      * Returns tag name of element.
      *
+     * 
      * @method tagName
      * @param {Function} callback node style [err, tagName].
      * @return {String} tag name of element.


### PR DESCRIPTION
Line 194
Documentation for method "tagName" updated
Add command "@return {String} tag name of element."
