### PR TITLE
Fix a typo causing a function call instead of function assignement.

### DIFF
--- a/lib/marionette/client.js
+++ b/lib/marionette/client.js
@@ -449,7 +449,7 @@
       }
 
       if (!cb && this.defaultCallback) {
-        cb = this.defaultCallback();
+        cb = this.defaultCallback;
       }
 
       var driverSent = this.driver.send(cmd, cb);


### PR DESCRIPTION
I don't think we wanted to call the default callback here but rather assign it.
