### PR TITLE
Bug 979666 - [marionette-js-client] The documentation for the text function .

### DIFF
--- a/lib/marionette/element.js
+++ b/lib/marionette/element.js
@@ -177,7 +177,7 @@
      *
      * @method text
      * @param {Function} callback text of element.
-     * @return {Object} self.
+     * @return {String} text of element.
      */
     text: function text(callback) {
       var cmd = {


### PR DESCRIPTION
Bug 979666 - [marionette-js-client] The documentation for the text function is not correct.
