### PR TITLE
Bug 980541 - Set the poll timeout in the tcp sync driver to avoid hangs.

### DIFF
--- a/lib/marionette/client.js
+++ b/lib/marionette/client.js
@@ -918,6 +918,7 @@
     setScriptTimeout: function setScriptTimeout(timeout, callback) {
       var cmd = { name: 'setScriptTimeout', parameters: {ms: timeout} };
       setState(this, 'scriptTimeout', timeout);
+      this.driver.setScriptTimeout(timeout);
       return this._sendCommand(cmd, 'ok', callback);
     },
 

--- a/lib/marionette/drivers/abstract.js
+++ b/lib/marionette/drivers/abstract.js
@@ -52,6 +52,16 @@
     connectionId: null,
 
     /**
+     * We just set the script timeout.
+     * If you need to do something in the driver.
+     *
+     * @method setScriptTiemout
+     * @param {Integer} the timeout value.
+     */
+    setScriptTimeout: function setScriptTimeout(timeout) {
+    },
+
+    /**
      * Sends remote command to server.
      * Each command will be queued while waiting for
      * any pending commands. This ensures order of

--- a/lib/marionette/drivers/tcp-sync.js
+++ b/lib/marionette/drivers/tcp-sync.js
@@ -3,6 +3,7 @@ var debug = require('debug')('marionette:tcp-sync');
 var sockittome = require('sockit-to-me');
 var DEFAULT_HOST = 'localhost';
 var DEFAULT_PORT = 2828;
+var SOCKET_TIMEOUT_EXTRA = 500;
 
 function TcpSync(options) {
   if (!options) {
@@ -20,6 +21,7 @@ function TcpSync(options) {
   }
 
   this.sockit = new sockittome.Sockit();
+  this.sockit.setPollTimeout(this.connectionTimeout + SOCKET_TIMEOUT_EXTRA);
 };
 
 TcpSync.prototype.isSync = true;
@@ -27,6 +29,10 @@ TcpSync.prototype.host = DEFAULT_HOST;
 TcpSync.prototype.port = DEFAULT_PORT;
 TcpSync.prototype.connectionTimeout = 2000;
 TcpSync.prototype.retryInterval = 300;
+
+TcpSync.prototype.setScriptTimeout = function(timeout) {
+  this.sockit.setPollTimeout(timeout + SOCKET_TIMEOUT_EXTRA);
+};
 
 TcpSync.prototype.connect = function(callback) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marionette-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "lib/marionette/index",
   "description": "Marionette Javascript Client",
   "author": "James Lal",
@@ -8,7 +8,7 @@
     "debug": "~0.6",
     "json-wire-protocol": "~0.2.1",
     "socket-retry-connect": "~0.0.1",
-    "sockit-to-me": "~0.1"
+    "sockit-to-me": "~0.2"
   },
   "scripts": {
     "test": "make ci REPORTER=dot"

--- a/test/marionette/client-test.js
+++ b/test/marionette/client-test.js
@@ -699,6 +699,11 @@ suite('marionette/client', function() {
       test('should update .scriptTimeout', function() {
         assert.strictEqual(subject.scriptTimeout, 100);
       });
+
+      test('driver should have gotten it', function() {
+        // this only work with the MockDevice.
+        assert.strictEqual(subject.driver.timeout, 100);
+      });
     });
   });
 

--- a/test/support/mock-driver.js
+++ b/test/support/mock-driver.js
@@ -3,11 +3,16 @@
   function MockDriver() {
     this.sent = [];
     this.queue = [];
+    this.timeout = 0;
   }
 
   MockDriver.prototype = {
 
     connectionId: 0,
+
+    setScriptTimeout: function(timeout) {
+      this.timeout = timeout;
+    },
 
     reset: function() {
       this.sent.length = 0;


### PR DESCRIPTION
This needs https://github.com/mozilla-b2g/sockit-to-me/pull/14 for sockit-to-me first.
