### PR TITLE
bug 1121223 - Use sockit-to-me built in socket timeout to avoid socket m...

### DIFF
--- a/lib/marionette/drivers/tcp-sync.js
+++ b/lib/marionette/drivers/tcp-sync.js
@@ -60,6 +60,10 @@ TcpSync.prototype.waitForSocket = function(options, callback) {
   var start = Date.now();
   var self = this;
 
+  // Use sockittome's built in polling timeout during calls to connect
+  // to avoid socket misuse.
+  sockit.setPollTimeout(interval);
+
   function probeSocket() {
     try {
       debug('probing socket');


### PR DESCRIPTION
...isuse. r=lightsofapollo