### PR TITLE
Bug 1150523: Support WebDriver error strings

### DIFF
--- a/lib/marionette/error.js
+++ b/lib/marionette/error.js
@@ -1,30 +1,52 @@
 (function(module, ns) {
 
-  var DEFAULT_CODE = 500;
-  var CODES = Object.freeze({
-   7: 'NoSuchElement',
-   8: 'NoSuchFrame',
-   9: 'UnknownCommand',
-   10: 'StaleElementReference',
-   11: 'ElementNotVisible',
-   12: 'InvalidElementState',
-   13: 'UnknownError',
-   15: 'ElementIsNotSelectable',
-   17: 'JavaScriptError',
-   19: 'XPathLookupError',
-   21: 'Timeout',
-   23: 'NoSuchWindow',
-   24: 'InvalidCookieDomain',
-   25: 'UnableToSetCookie',
-   26: 'UnexpectedAlertOpen',
-   27: 'NoAlertOpenError',
-   28: 'ScriptTimeout',
-   29: 'InvalidElementCoordinates',
-   30: 'IMENotAvailable',
-   31: 'IMEEngineActivationFailed',
-   32: 'InvalidSelector',
-   500: 'GenericError'
+  var STATUSES = Object.freeze({
+    'no such element': 'NoSuchElement',
+    'no such frame': 'NoSuchFrame',
+    'unknown command': 'UnknownCommand',
+    'stale element reference': 'StaleElementReference',
+    'element not visible': 'ElementNotVisible',
+    'invalid element state': 'InvalidElementState',
+    'unknown error': 'UnknownError',
+    'element not selectable': 'ElementIsNotSelectable',
+    'javascript error': 'JavaScriptError',
+    'invalid xpath selector': 'XPathLookupError',
+    'timeout': 'Timeout',
+    'no such window': 'NoSuchWindow',
+    'invalid cookie domain': 'InvalidCookieDomain',
+    'unable to set cookie': 'UnableToSetCookie',
+    'unexpected alert open': 'UnexpectedAlertOpen',
+    'no such alert': 'NoAlertOpenError',
+    'script timeout': 'ScriptTimeout',
+    'invalid element coordinates': 'InvalidElementCoordinates',
+    'invalid selector': 'InvalidSelector',
+    'webdriver error': 'GenericError'
   });
+
+  var CODES = Object.freeze({
+    7: STATUSES['no such element'],
+    8: STATUSES['no such frame'],
+    9: STATUSES['unknown command'],
+    10: STATUSES['stale element reference'],
+    11: STATUSES['element not visible'],
+    12: STATUSES['invalid element state'],
+    13: STATUSES['unknown error'],
+    15: STATUSES['element not selectable'],
+    17: STATUSES['javascript error'],
+    19: STATUSES['invalid xpath selector'],
+    21: STATUSES['timeout'],
+    23: STATUSES['no such window'],
+    24: STATUSES['invalid cookie domain'],
+    25: STATUSES['unable to set cookie'],
+    26: STATUSES['unexpected alert open'],
+    27: STATUSES['no such alert'],
+    28: STATUSES['script timeout'],
+    29: STATUSES['invalid element coordinates'],
+    32: STATUSES['invalid selector'],
+    500: STATUSES['webdriver error']
+  });
+
+  var DEFAULT_STATUS = STATUSES['webdriver error'];
 
   /**
    * Returns an error object given
@@ -34,31 +56,32 @@
    * Codes are from:
    * http://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_Codes
    *
+   * Status strings are from:
+   * https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors
+   *
    *    {
    *      message: "Something",
    *      stacktrace: "wentwrong@line",
-   *      status: 17
+   *      status: "javascript error"
    *    }
    *
    * @param {Client} client which the error originates from.
    * @param {Object} options for error (see above).
    */
   function MarionetteError(client, options) {
-    // default to unknown error
-    var code = options.status || DEFAULT_CODE;
-
-    if (!(code in CODES))
-      code = DEFAULT_CODE;
+    var status = DEFAULT_STATUS;
+    if (options.status in CODES)
+      status = CODES[options.status];
+    else if (options.status in STATUSES)
+      status = STATUSES[options.status];
 
     this.client = client;
-    this.type = this.name = CODES[code];
-    this.message = '';
+    this.type = status;
+    this.name = this.type;
 
-    if (code) {
-      this.message += '(' + code + ') ';
-    }
-
-    this.message += (options.message || '');
+    this.message = this.name;
+    if (options.message)
+      this.message += ': ' + options.message;
     this.message += '\nRemote Stack:\n';
     this.message += options.stacktrace || '<none>';
 
@@ -80,6 +103,7 @@
     }
   });
 
+  MarionetteError.STATUSES = STATUSES;
   MarionetteError.CODES = CODES;
   module.exports = MarionetteError;
 

--- a/lib/marionette/example-commands.js
+++ b/lib/marionette/example-commands.js
@@ -98,12 +98,23 @@
       { from: 'actor', value: ['{some-uuid}', '{some-other-uuid}'] }
     ),
 
-    error: cmd(
+    numberError: cmd(
       {
         from: 'actor',
         error: {
           message: 'you fail',
-          status: 1,
+          status: 7,
+          stacktrace: 'fail@url\nother:300'
+        }
+      }
+    ),
+
+    stringError: cmd(
+      {
+        from: 'actor',
+        error: {
+          message: 'you fail',
+          status: 'no such element',
           stacktrace: 'fail@url\nother:300'
         }
       }

--- a/test/integration/error-test.js
+++ b/test/integration/error-test.js
@@ -1,4 +1,9 @@
 suite('error handling', function() {
+  var MarionetteError;
+  helper.require('error', function(obj) {
+    MarionetteError = obj;
+  });
+
   var client = marionette.client();
 
   test('catch error', function() {
@@ -8,6 +13,27 @@ suite('error handling', function() {
       });
     } catch (e) {
       e.client.screenshot();
+    }
+  });
+
+  test('throws no such element error', function() {
+    try {
+      client.findElement('cheese');
+      assert.fail('expected no such element error to be thrown');
+    } catch (e) {
+      assert.include(e.toString(), 'NoSuchElement');
+      assert.property(e, 'type');
+      assert.equal(e.type, 'NoSuchElement');
+    }
+  });
+
+  test('throws javascript error', function() {
+    try {
+      client.executeScript(function() { throw Error('rochefort'); });
+    } catch (e) {
+      assert.include(e.toString(), 'JavaScriptError');
+      assert.property(e, 'type');
+      assert.equal(e.type, 'JavaScriptError');
     }
   });
 });

--- a/test/marionette/client-test.js
+++ b/test/marionette/client-test.js
@@ -194,7 +194,7 @@ suite('marionette/client', function() {
 
     function usesCallback() {
 
-      test('should handle errors', function() {
+      test('should handle number errors', function() {
         var calledWith, err;
 
         err = {
@@ -208,8 +208,26 @@ suite('marionette/client', function() {
         }, err, null);
 
         assert.instanceOf(calledWith[0], Exception);
-
         assert.include(calledWith[0].message, 'foo');
+        assert.include(calledWith[0].stack, 'bar');
+      });
+
+      test('should handle string errors', function() {
+        var calledWith, err;
+
+        err = {
+          status: 'no such element',
+          message: 'foo',
+          stacktrace: 'bar'
+        };
+
+        subject._handleCallback(function() {
+          calledWith = arguments;
+        }, err, null);
+
+        assert.instanceOf(calledWith[0], Exception);
+        assert.include(calledWith[0].message, 'foo');
+        assert.include(calledWith[0].stack, 'bar');
       });
 
       test('should use callback when provided', function(done) {
@@ -227,7 +245,7 @@ suite('marionette/client', function() {
         };
 
         var err = {
-          status: 28,
+          status: 'script timeout',
           message: 'foo',
           stacktrace: 'bar'
         };
@@ -455,12 +473,34 @@ suite('marionette/client', function() {
 
     });
 
-    suite('on error', function() {
+    suite('on number error', function() {
 
       setup(function(done) {
         calledWith = null;
         cmd = exampleCmds.getUrl();
-        response = exampleCmds.error();
+        response = exampleCmds.numberError();
+
+        subject._sendCommand(cmd, 'value', function(err, data) {
+          calledWith = arguments;
+          done();
+        });
+
+        driver.respond(response);
+      });
+
+      test('should pass error to callback', function() {
+        assert.ok(calledWith[0]);
+        assert.notOk(calledWith[1]);
+      });
+
+    });
+
+    suite('on string error', function() {
+
+      setup(function(done) {
+        calledWith = null;
+        cmd = exampleCmds.getUrl();
+        response = exampleCmds.stringError();
 
         subject._sendCommand(cmd, 'value', function(err, data) {
           calledWith = arguments;
@@ -478,7 +518,6 @@ suite('marionette/client', function() {
     });
 
   });
-
 
   suite('.deleteSession', function() {
     var result;

--- a/test/marionette/error-test.js
+++ b/test/marionette/error-test.js
@@ -10,19 +10,68 @@ suite('marionette/error', function() {
     assert.operator(Object.keys(MarionetteError.CODES).length, '>', 0);
   });
 
+  test('should expose .STATUSES', function() {
+    assert.operator(Object.keys(MarionetteError.STATUSES).length, '>', 0);
+  });
+
   suite('#error', function() {
-    test('should have support for each error', function() {
-      for (var key in MarionetteError.CODES) {
-        err = new MarionetteError({}, {
-          message: 'msg',
-          status: key,
-          stacktrace: 'stack'
-        });
-        assert.strictEqual(err.type, MarionetteError.CODES[key]);
-        assert.include(err.message, key);
-        assert.include(err.message, 'stack');
-        assert.include(err.message, 'msg');
-        assert.ok(err.stack);
+    test('should populate message', function() {
+      err = new MarionetteError({}, {message: 'msg'});
+      assert.property(err, 'message');
+      assert.include(err.message, 'msg');
+    });
+
+    test('should populate stacktrace', function() {
+      var trace = 'brie';
+      err = new MarionetteError({}, {stacktrace: trace});
+      assert.property(err, 'stack');
+      assert.include(err.message, trace);
+      assert.include(err.stack, trace);
+    });
+
+    test('should populate type', function() {
+      err = new MarionetteError({}, {});
+      assert.property(err, 'type');
+    });
+
+    test('should recognise known number', function() {
+      err = new MarionetteError({}, {status: 7});
+      assert.property(err, 'type');
+      assert.equal(err.type, 'NoSuchElement');
+    });
+
+    test('should recognise known string', function() {
+      err = new MarionetteError({}, {status: 'no such element'});
+      assert.property(err, 'type');
+      assert.equal(err.type, 'NoSuchElement');
+    });
+
+    test('should fall back to GenericError for unknown number', function() {
+      err = new MarionetteError({}, {status: 666});
+      assert.property(err, 'type');
+      assert.equal(err.type, 'GenericError');
+    });
+
+    test('should fall back to GenericError for unknown string', function() {
+      err = new MarionetteError({}, {status: 'brunost'});
+      assert.property(err, 'type');
+      assert.equal(err.type, 'GenericError');
+    });
+
+    test('should support all error number codes', function() {
+      for (var n in MarionetteError.CODES) {
+        err = new MarionetteError({}, {status: n});
+        assert.strictEqual(err.type, MarionetteError.CODES[n]);
+        assert.include(err.message, MarionetteError.CODES[n]);
+        assert.instanceOf(err, Error);
+      }
+    });
+
+    test('should support all error status strings', function() {
+      for (var s in MarionetteError.STATUSES) {
+        err = new MarionetteError({}, {status: s});
+        assert.strictEqual(err.type, MarionetteError.STATUSES[s]);
+        assert.include(err.message, MarionetteError.STATUSES[s]);
         assert.instanceOf(err, Error);
       }
     });
@@ -36,17 +85,17 @@ suite('marionette/error', function() {
       });
 
       assert.equal(result.client, client);
-      assert.strictEqual(result.name, MarionetteError.CODES[500]);
+      assert.strictEqual(result.name, MarionetteError.STATUSES['webdriver error']);
     });
 
-    test('should use 500 error when unknown stack is given', function() {
-      var result = new MarionetteError({}, {
-        status: 7777,
-        message: 'foo',
-        stack: 'bar'
-      });
+    test('should use GenericError error when unknown error code is given', function() {
+      var result = new MarionetteError({}, {status: 7777});
+      assert.strictEqual(result.name, MarionetteError.STATUSES['webdriver error']);
+    });
 
-      assert.strictEqual(result.name, MarionetteError.CODES[500]);
+    test('should use GenericError error when unknown error status is given', function() {
+      var result = new MarionetteError({}, {status: 'cheese'});
+      assert.strictEqual(result.name, MarionetteError.STATUSES['webdriver error']);
     });
   });
 


### PR DESCRIPTION
Adds string based statuses as defined by the W3C WebDriver protocol.
Importantly, it does not remove the ability to look up errors by their
Selenium protocol number for backwards compatibility reasons.