### PR TITLE
Bug 1155708: Make Element#size and #location use rect

### DIFF
--- a/lib/marionette/element.js
+++ b/lib/marionette/element.js
@@ -308,9 +308,7 @@
       var cmd = {
         name: 'getElementRect'
       };
-      var resp = this._sendCommand(cmd, 'value', callback);
-      console.log(resp);
-      return resp;
+      return this._sendCommand(cmd, 'value', callback);
     },
 
     /**

--- a/lib/marionette/element.js
+++ b/lib/marionette/element.js
@@ -296,8 +296,8 @@
      *
      *    // returned in callback or result of this call in the sync driver.
      *    {
-     *      x: Number,
-     *      y: Number
+     *      width: Number,
+     *      height: Number
      *    }
      *
      * @method size
@@ -306,9 +306,11 @@
      */
     size: function size(callback) {
       var cmd = {
-        name: 'getElementSize'
+        name: 'getElementRect'
       };
-      return this._sendCommand(cmd, 'value', callback);
+      var resp = this._sendCommand(cmd, 'value', callback);
+      console.log(resp);
+      return resp;
     },
 
     /**
@@ -328,7 +330,7 @@
      */
     location: function location(callback) {
       var cmd = {
-        name: 'getElementPosition'
+        name: 'getElementRect'
       };
       return this._sendCommand(cmd, 'value', callback);
     },

--- a/test/integration/element-test.js
+++ b/test/integration/element-test.js
@@ -1,12 +1,12 @@
 suite('element methods', function() {
+  var querystring = require('querystring');
   var Marionette = require('../../');
-  // TODO: use a static server
-  var URL = 'http://mozilla.org';
 
   var client = marionette.client();
 
   setup(function() {
-    client.goUrl(URL);
+    client.goUrl("data:text/html," + querystring.escape(
+        '<div id="el" style="width: 50px; height: 50px">cheese</div>'));
   });
 
   test('#displayed', function() {
@@ -24,22 +24,19 @@ suite('element methods', function() {
   });
 
   test('#findElement', function() {
-    var root = client.findElement('html');
-    assert.ok(root.findElement('body').displayed());
+    client.findElement('html');
   });
 
   test('#findElements', function() {
-    var root = client.findElement('html');
-    var elements = root.findElements('body');
-    assert.ok(Array.isArray(elements), 'is an array');
-    assert.ok(elements[0].displayed());
+    var elements = client.findElements('html');
+    assert.isArray(elements);
   });
 
   test('#findElement - missing', function() {
     var err;
     try {
       client.findElement('#fooobaramazingmissing');
-    } catch(e) {
+    } catch (e) {
       err = e;
     }
 
@@ -53,20 +50,30 @@ suite('element methods', function() {
     assert.ok(font, 'returns a css property value');
   });
 
-  test('#rect', function () {
-    // Create our dummy rect for the tests...
-    client.executeScript(function() {
-      var html =
-        '<div id="magic-testing" style="width: 50px; height: 50px">woot</div>';
-      document.body.insertAdjacentHTML('beforeend', html);
-    });
+  test('#size', function () {
+    var element = client.findElement('#el');
+    var size = element.size();
+    assert.property(size, 'width');
+    assert.property(size, 'height');
+    assert.equal(size.width, 50);
+    assert.equal(size.height, 50);
+  });
 
-    var element = client.findElement('#magic-testing');
+  test('#location', function () {
+    var element = client.findElement('#el');
+    var location = element.location();
+    assert.property(location, 'x');
+    assert.property(location, 'y');
+  });
+
+  test('#rect', function () {
+    var element = client.findElement('#el');
     var rect = element.rect();
-    console.log(rect);
-    assert.ok('x' in rect, "is in the object");
-    assert.ok('y' in rect, "is in the object");
+    assert.property(rect, 'x');
+    assert.property(rect, 'y');
+    assert.property(rect, 'width');
+    assert.property(rect, 'height');
     assert.equal(rect.width, 50);
     assert.equal(rect.height, 50);
-  })
+  });
 });

--- a/test/integration/element-test.js
+++ b/test/integration/element-test.js
@@ -24,12 +24,14 @@ suite('element methods', function() {
   });
 
   test('#findElement', function() {
-    client.findElement('html');
+    var el = client.findElement('html');
+    assert.instanceOf(el, Marionette.Element);
   });
 
   test('#findElements', function() {
-    var elements = client.findElements('html');
-    assert.isArray(elements);
+    var els = client.findElements('html');
+    assert.isArray(els);
+    els.forEach(function(el) { assert.instanceOf(el, Marionette.Element); });
   });
 
   test('#findElement - missing', function() {

--- a/test/marionette/element-test.js
+++ b/test/marionette/element-test.js
@@ -1,5 +1,4 @@
-//this is hack to ensure device interactions are
-//loaded
+// this is hack to ensure device interactions are loaded
 
 suite('marionette/element', function() {
   var driver, subject, client, id, device,
@@ -275,8 +274,8 @@ suite('marionette/element', function() {
   simpleCommand('selected', 'isElementSelected', 'value');
   simpleCommand('enabled', 'isElementEnabled', 'value');
   simpleCommand('displayed', 'isElementDisplayed', 'value');
-  simpleCommand('size', 'getElementSize', 'value');
-  simpleCommand('location', 'getElementPosition', 'value');
+  simpleCommand('size', 'getElementRect', 'value');
+  simpleCommand('location', 'getElementRect', 'value');
   simpleCommand('rect', 'getElementRect', 'value')
 
 });


### PR DESCRIPTION
getElementLocation and getElementSize in Marionette are deprecated in
favour of the less bandwidth-intensive getElementRect.

Fortunately, it's backwards-compatible and we should be able to call
that function for Marionette.Element#size and Marionette.Element#location
and extract the properties we are interested in.

r=gaye