### PR TITLE
Remove default printing of screenshot on script timeout

### DIFF
--- a/lib/marionette/client.js
+++ b/lib/marionette/client.js
@@ -409,13 +409,10 @@
      * This function will be invoked whenever the remote throws a
      * ScriptTimeout error. The motivation is that client consumers
      * can use this opportunity to log some useful state for debugging.
-     * By default this function logs screenshot image data.
      *
      * @type {Function}
      */
-    onScriptTimeout: function() {
-      console.log('Screenshot: ' + 'data:image/png;base64,' + this.screenshot());
-    },
+    onScriptTimeout: function() {},
 
     /**
      * Sends a command to the server.


### PR DESCRIPTION
If users are interested in logging the screenshot when a script timeout occurs, they can define this handler explicitly.  It’s very disruptive to the test suite and other uses of marionette-js-client that it logs this by default.  This helps reducing the amount of output from running the tests.